### PR TITLE
Fix missing import in backtrace_to_dicom and correct test paths

### DIFF
--- a/src/backtrace_to_dicom.py
+++ b/src/backtrace_to_dicom.py
@@ -3,7 +3,7 @@ import csv
 import numpy as np
 import pydicom
 from pydicom import dcmread
-from PIL import Image
+from PIL import Image, ImageDraw
 
 try:
     import nibabel as nib  # for NIfTI loading if needed

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -7,7 +7,7 @@
 #
 
 # Source modules
-source modules/environment.sh
+source src/modules/environment.sh
 
 # Print header
 echo "=== Module Integration Test ==="

--- a/tests/test_parallel.sh
+++ b/tests/test_parallel.sh
@@ -7,8 +7,8 @@
 #
 
 # Source modules
-source modules/environment.sh
-source modules/preprocess.sh
+source src/modules/environment.sh
+source src/modules/preprocess.sh
 
 # Print header
 echo "=== Parallel Processing Test ==="


### PR DESCRIPTION
## Summary
- fix missing `ImageDraw` import in `backtrace_to_dicom.py`
- update test scripts to source modules from `src/modules`

## Testing
- `bash tests/test_integration.sh` *(fails: required dependencies missing)*
- `bash tests/test_parallel.sh`