### PR TITLE
Fix OUTPUT_DATATYPE typo

### DIFF
--- a/config/default_config.sh
+++ b/config/default_config.sh
@@ -23,7 +23,7 @@ export RESULTS_DIR="../mri_results"
 # Pipeline Parameters / Presets
 # ------------------------------------------------------------------------------
 export PROCESSING_DATATYPE="float"  # internal float
-export UTPUT_DATATYPE="int"        # final int16
+export OUTPUT_DATATYPE="int"        # final int16
 
 # Quality settings (LOW, MEDIUM, HIGH)
 export QUALITY_PRESET="HIGH"


### PR DESCRIPTION
## Summary
- fix typo in `default_config.sh` so `OUTPUT_DATATYPE` is exported correctly

## Testing
- `bash tests/test_integration.sh` *(fails: modules not found)*
- `bash tests/test_parallel.sh` *(fails: modules not found)*